### PR TITLE
cleaning up the route->model->component workflow

### DIFF
--- a/static/js/src/components/workshop/workshop.js
+++ b/static/js/src/components/workshop/workshop.js
@@ -4,13 +4,15 @@ export default function($timeout, $stateParams, code, blockly, Workspaces) {
   return {
     template: template,
     controllerAs: 'vm',
-    controller: function() {
+    scope: {
+      model: '='
+    },
+    controller: function($scope) {
+      this.workshop = $scope.model;
       this.selected = 'blocks';
       this.selectBlocks = selectBlocks;
       this.selectCode = selectCode;
-      this.workshopId = $stateParams.workshopId;
-
-      restoreWorkspace( this.workshopId );
+      restoreWorkspace( this.workshop._id );
 
       function selectBlocks() {
         this.selected = 'blocks';

--- a/static/js/src/components/workshops/workshops.js
+++ b/static/js/src/components/workshops/workshops.js
@@ -4,10 +4,11 @@ export default function(Workshops) {
   return {
     template: template,
     controllerAs: 'vm',
+    scope: {
+      model: '='
+    },
     controller: function($scope) {
-      Workshops.query().then(function(workshops) {
-        this.workshops = workshops;
-      }.bind(this));
+      this.workshops = $scope.model;
     }
   };
 }

--- a/static/js/src/models/workshops.js
+++ b/static/js/src/models/workshops.js
@@ -5,14 +5,13 @@ function Workshops($q, pouchDB) {
   var db = pouchDB('Workshops');
 
   function query() {
-    return $q(function(resolve, reject) {
-      db.allDocs({
-        include_docs: true
-      }).then(function(result) {
-        var workshops = result.rows.map( w => w.doc );
-        resolve( workshops );
-      });
-    });
+    return db.allDocs({ 
+      include_docs: true
+    }).then(result => result.rows.map( w => w.doc ));
+  }
+
+  function get(id) {
+    return db.get(id);
   }
 
   // Create initial records, but only if the document database is empty
@@ -25,7 +24,7 @@ function Workshops($q, pouchDB) {
   }
   initializeBundledWorkshops();
 
-  return { query };
+  return { query, get };
 }
 
 export default Workshops;

--- a/static/js/src/models/workspaces.js
+++ b/static/js/src/models/workspaces.js
@@ -5,14 +5,10 @@ function Workspaces($q, pouchDB) {
   var db = pouchDB('Workspaces');
 
   function load(workshopId) {
-    return $q(function(resolve, reject) {
-      db.find({
-        selector: { workshopId },
-        limit: 1
-      }).then(function(result) {
-        resolve( result.docs[0] );
-      });
-    });
+    return db.find({
+      selector: { workshopId },
+      limit: 1
+    }).then(result => result.docs[0]);
   }
 
   function save(data) {

--- a/static/js/src/routes.js
+++ b/static/js/src/routes.js
@@ -2,14 +2,30 @@ function routes($stateProvider, $urlRouterProvider) {
 
   $urlRouterProvider.otherwise("/workshops");
 
+  function defaultModelController($scope, model) {
+    $scope.model = model;
+  }
+
   $stateProvider
     .state('workshops', {
       url: '/workshops',
-      template: "<workshops></workshops>"
+      template: '<workshops model="model"></workshops>',
+      controller: defaultModelController,
+      resolve: {
+        model: function(Workshops){
+          return Workshops.query();
+        }
+      }
     })
     .state('workshop', {
       url: '/workshops/:workshopId',
-      template: "<workshop></workshop>"
+      template: '<workshop model="model"></workshop>',
+      controller: defaultModelController,
+      resolve: {
+        model: function(Workshops, $stateParams) {
+          return Workshops.get($stateParams.workshopId);
+        }
+      }
     });
 
 }


### PR DESCRIPTION
This PR is preparing me to take the workshop and transform it to the blocks configuration.  

Using the Angular router (like in many SPA frameworks), the router is actually responsible for fetching the data, not the controller.  So I moved the behavior of model fetching to the route, and I pass it to the component as a "model" parameter, which the component can give a better name to.

I also took this opportunity to clean up the model code a bit.  We don't need to include `$q` in the model functions because the `angular-pouchdb` module does it for us.  We can just chain the promises.
