### PR TITLE
removed napa dependency for blockly and updated electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "postinstall": "bower install && gulp",
-    "start": "electron .",
-    "install": "napa"
+    "start": "electron ."
   },
   "repository": {
     "type": "git",
@@ -41,10 +40,11 @@
     "angular-pouchdb": "^2.0.6",
     "angular-resource": "^1.3.15",
     "angular-ui-router": "^0.2.14",
+    "blockly": "git+https://github.com/google/blockly.git",
     "body-parser": "^1.12.3",
     "bower": "^1.3.12",
     "browserify": "^9.0.3",
-    "electron-prebuilt": "^0.25.2",
+    "electron-prebuilt": "^0.37.2",
     "johnny-five": "^0.8.71",
     "jquery": "^2.1.4",
     "js-beautify": "^1.5.5",
@@ -59,12 +59,8 @@
     "gulp-concat-json": "^1.0.0",
     "gulp-uglify": "^1.1.0",
     "gulp-watch": "^4.2.4",
-    "napa": "^1.2.0",
     "partialify": "^3.1.3",
     "robotnik-controls": "0.0.1",
     "vinyl-source-stream": "^1.0.0"
-  },
-  "napa": {
-    "blockly": "https://github.com/google/blockly.git"
   }
 }


### PR DESCRIPTION
First step on making the install process easier (and RPI compatible), simply removing the napa dependency and npm installing directly from git. In addition updated Electron to a much newer version which allows debugging and has a native build for the RPi.
